### PR TITLE
docs: clarify wildcard round rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For additional setup guidance, see the [official Devvit documentation](https://d
 ## 🏆 Scoring System
 
 - **Normal Rounds**: The card with more word/synonym matches wins
-- **Wildcard Rounds**: When both cards have 0 matches, winner is determined by upvotes, then comment count
+- **Wildcard Rounds**: When both cards have the same number of matches, winner is determined by upvotes, then comment count
 - **Statistics**: Track wins, losses, ties, current streak, longest streak, and unique words learned
 
 ## Commands


### PR DESCRIPTION
## Summary
- clarify wildcard round winner criteria in README

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string')*

------
https://chatgpt.com/codex/tasks/task_e_68bb969867488320a86f5821cd8a9711